### PR TITLE
Support for CJS Configs

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -16,7 +16,7 @@ const readFile = promisify(fs.readFile);
 const env = {
   modulePath: resolveFrom.silent(process.cwd(), 'sutando') || findUpModulePath(process.cwd(), 'sutando'),
   cwd: process.cwd(),
-  configPath: findUpConfig(process.cwd(), 'sutando.config', ['js'])
+  configPath: findUpConfig(process.cwd(), 'sutando.config', ['js','cjs'])
 }
 
 let modulePackage = {};


### PR DESCRIPTION
`.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.`