### PR TITLE
fix updateOrCreate

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -864,7 +864,7 @@ class Builder {
   }
 
   async updateOrCreate(attributes, values = {}) {
-    return await tap(this.firstOrNew(attributes), async (instance) => {
+    return await tap(await this.firstOrNew(attributes), async (instance) => {
       await instance.fill(values).save({
         client: this.query
       });


### PR DESCRIPTION
The firstOrNew method is async and returns a Promise, but it's being passed directly to tap, which expects the actual instance.